### PR TITLE
Fix scheduler initialization in AdaptiveExecutor

### DIFF
--- a/tygent/adaptive_executor.py
+++ b/tygent/adaptive_executor.py
@@ -52,7 +52,9 @@ class AdaptiveExecutor:
         self.base_dag = base_dag
         self.rewrite_rules = rewrite_rules or []
         self.max_modifications = max_modifications
-        self.scheduler = Scheduler()
+        # Initialize the scheduler with the base DAG so it is ready to execute
+        # immediately when no modifications are required.
+        self.scheduler = Scheduler(self.base_dag)
 
     async def execute(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- ensure AdaptiveExecutor creates a Scheduler using the base DAG

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: AssertionError in salesforce tests)*

------
https://chatgpt.com/codex/tasks/task_e_685585e8bf70832b9a0f00b718030fa0