### PR TITLE
Fix CommunicationBus field names

### DIFF
--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -78,8 +78,8 @@ class TestCommunicationBus(unittest.TestCase):
 
             self.assertEqual(len(self.bus.messages), 1)
             message = self.bus.messages[0]
-            self.assertEqual(message["sender"], "agent1")
-            self.assertEqual(message["recipient"], "agent2")
+            self.assertEqual(message["from_agent"], "agent1")
+            self.assertEqual(message["to_agent"], "agent2")
             self.assertEqual(message["content"], "Hello!")
             self.assertTrue("timestamp" in message)
 

--- a/tygent/multi_agent.py
+++ b/tygent/multi_agent.py
@@ -39,8 +39,8 @@ class CommunicationBus:
             content: The message content
         """
         message = {
-            "sender": sender,
-            "recipient": recipient,
+            "from_agent": sender,
+            "to_agent": recipient,
             "content": content,
             "timestamp": asyncio.get_event_loop().time(),
         }
@@ -60,12 +60,12 @@ class CommunicationBus:
             List of messages for the agent
         """
         if since is None:
-            return [m for m in self.messages if m["recipient"] == recipient]
+            return [m for m in self.messages if m["to_agent"] == recipient]
         else:
             return [
                 m
                 for m in self.messages
-                if m["recipient"] == recipient and m["timestamp"] > since
+                if m["to_agent"] == recipient and m["timestamp"] > since
             ]
 
 


### PR DESCRIPTION
## Summary
- update CommunicationBus message keys to use `from_agent` and `to_agent`
- adjust receive logic for new field names
- update tests for new names

## Testing
- `pytest tests/test_multi_agent.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tygent')*

------
https://chatgpt.com/codex/tasks/task_e_685585ee684c832bae637106dc98fc67