### PR TITLE
Add plan auditing and node execution logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ result = asyncio.run(
 - **🔄 Dynamic Adaptation**: Runtime DAG modification based on conditions and failures
 - **🎯 Multi-Framework Support**: Works with CrewAI, HuggingFace, Google AI, and custom agents
 - **📄 Plan Parsing**: Build DAGs directly from framework plans or dictionaries
-- **📋 Auditing & Tracing**: Inspect plans before execution and record node results
+- **📋 Auditing & Tracing**: Inspect plans, hook into node execution, and record results
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ result = asyncio.run(
 - **🔄 Dynamic Adaptation**: Runtime DAG modification based on conditions and failures
 - **🎯 Multi-Framework Support**: Works with CrewAI, HuggingFace, Google AI, and custom agents
 - **📄 Plan Parsing**: Build DAGs directly from framework plans or dictionaries
+- **📋 Auditing & Tracing**: Inspect plans before execution and record node results
 
 ## Architecture
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,36 @@
+import asyncio
+import unittest
+
+from tygent import DAG, Scheduler, ToolNode
+
+
+class TestHooks(unittest.TestCase):
+    def test_stop_via_hook(self):
+        events = []
+
+        async def hook(stage, node, inputs, output, scheduler):
+            events.append((stage, node.name))
+            if stage == "after_execute" and node.name == "a":
+                return False
+
+        async def a_fn(inputs):
+            return {"val": 1}
+
+        async def b_fn(inputs):
+            return {"done": True}
+
+        dag = DAG("hooks")
+        dag.add_node(ToolNode("a", a_fn))
+        dag.add_node(ToolNode("b", b_fn))
+        dag.add_edge("a", "b", {"val": "val"})
+
+        scheduler = Scheduler(dag, hooks=[hook])
+
+        result = asyncio.run(scheduler.execute({}))
+        self.assertIn("a", result["results"])
+        self.assertNotIn("b", result["results"])
+        self.assertIn(("audit", "a"), events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tygent/__init__.py
+++ b/tygent/__init__.py
@@ -17,6 +17,7 @@ from .adaptive_executor import (
     create_resource_adaptation_rule,
 )
 from .agent import Agent
+from .audit import audit_dag, audit_plan, audit_plans
 
 # Import core modules
 from .dag import DAG
@@ -45,5 +46,8 @@ __all__ = [
     "create_resource_adaptation_rule",
     "parse_plan",
     "parse_plans",
+    "audit_dag",
+    "audit_plan",
+    "audit_plans",
     "install",
 ]

--- a/tygent/__init__.py
+++ b/tygent/__init__.py
@@ -25,7 +25,7 @@ from .multi_agent import CommunicationBus, Message, MultiAgentManager
 from .nodes import BaseNode, LLMNode, Node, ToolNode
 from .patch import install
 from .plan_parser import parse_plan, parse_plans
-from .scheduler import Scheduler
+from .scheduler import Scheduler, StopExecution
 
 __all__ = [
     "DAG",
@@ -34,6 +34,7 @@ __all__ = [
     "ToolNode",
     "BaseNode",
     "Scheduler",
+    "StopExecution",
     "Agent",
     "MultiAgentManager",
     "CommunicationBus",

--- a/tygent/audit.py
+++ b/tygent/audit.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Utilities for auditing plans and DAG execution."""
+
+import json
+from typing import Any, Dict, Iterable, List
+
+from .dag import DAG
+from .plan_parser import parse_plan, parse_plans
+
+
+def audit_dag(dag: DAG) -> str:
+    """Return a human readable summary of a :class:`~tygent.dag.DAG`."""
+
+    lines = [f"DAG: {dag.name}"]
+    for name, node in dag.nodes.items():
+        deps = ", ".join(node.dependencies) if node.dependencies else "none"
+        lines.append(f"- {name}: depends on {deps}")
+    return "\n".join(lines)
+
+
+def audit_plan(plan: Dict[str, Any]) -> str:
+    """Generate an audit summary for a single plan dictionary."""
+
+    dag, _ = parse_plan(plan)
+    return audit_dag(dag)
+
+
+def audit_plans(plans: Iterable[Dict[str, Any]]) -> str:
+    """Generate an audit summary for multiple plan dictionaries."""
+
+    dag, _ = parse_plans(plans)
+    return audit_dag(dag)


### PR DESCRIPTION
## Summary
- add `audit_dag`, `audit_plan`, and `audit_plans` utilities
- export auditing helpers from the package
- record node execution details in `Scheduler` when `audit_file` is configured
- document auditing & tracing feature in README

## Testing
- `pip install -e .`
- `black tygent/audit.py tygent/__init__.py tygent/scheduler.py > /tmp/black.log`
- `isort tygent/audit.py tygent/__init__.py tygent/scheduler.py > /tmp/isort.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc905cdac832b82a06d727bb2c633