### PR TITLE
Add Google ADK spanner example

### DIFF
--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -1,0 +1,107 @@
+"""Example using Google ADK with and without Tygent acceleration.
+
+This script creates a simple Google ADK agent that answers the query:
+"Describe the Spanner paper by Google assuming I am a 10th grader, a junior undergraduate, and a first year graduate student."
+It then executes the query twice – once using standard execution and once
+with Tygent acceleration applied.
+"""
+
+import asyncio
+import os
+import time
+
+from dotenv import load_dotenv
+
+# Load environment variables (GOOGLE_API_KEY) from a .env file if present
+load_dotenv()
+
+try:
+    from google import genai
+    from google.adk.agents.llm_agent import LlmAgent
+    from google.adk.runners import Runner
+    from google.genai import types
+except ImportError:
+    print("This example requires the google-adk and google-genai packages.")
+    print("Install them with: pip install google-adk google-genai")
+    raise
+
+from tygent.integrations.google_adk import patch
+
+API_KEY = os.getenv("GOOGLE_API_KEY")
+if not API_KEY:
+    print("GOOGLE_API_KEY environment variable not set.")
+    print("Get an API key from https://makersuite.google.com/app/apikey")
+    raise SystemExit
+
+# Configure Google GenAI client
+client = genai.Client(api_key=API_KEY)
+
+# Create a simple LLM agent capable of explaining topics at different levels
+tag = LlmAgent(
+    name="spanner_explainer",
+    model="gemini-1.5-flash",
+    instruction=(
+        "You explain technical topics for different levels of expertise."
+        " Provide clear and concise responses."
+    ),
+)
+
+# Create a runner and session
+runner = Runner(tag)
+runner.session_service.create_session_sync(
+    app_name=runner.app_name, user_id="user", session_id="session"
+)
+
+QUERY = (
+    "Describe the Spanner paper by Google assuming I am a 10th grader, "
+    "a junior undergraduate, and a first year graduate student."
+)
+
+
+def format_events(events):
+    if not events:
+        return "No response"
+    event = events[-1]
+    parts = getattr(event.content, "parts", [])
+    if parts and hasattr(parts[0], "text"):
+        return parts[0].text
+    return str(event)
+
+
+async def run_without_tygent():
+    content = types.Content(role="user", parts=[types.Part(text=QUERY)])
+    events = []
+    async for event in runner.run_async(
+        user_id="user", session_id="session", new_message=content
+    ):
+        events.append(event)
+    return events
+
+
+async def run_with_tygent():
+    patch()  # Patch Runner.run_async to use Tygent scheduler
+    content = types.Content(role="user", parts=[types.Part(text=QUERY)])
+    events = []
+    async for event in runner.run_async(
+        user_id="user", session_id="session", new_message=content
+    ):
+        events.append(event)
+    return events
+
+
+async def main():
+    print("=== Without Tygent Acceleration ===")
+    start = time.time()
+    events = await run_without_tygent()
+    print(format_events(events))
+    print(f"Execution time: {time.time() - start:.2f}s\n")
+
+    print("=== With Tygent Acceleration ===")
+    start = time.time()
+    events = await run_with_tygent()
+    print(format_events(events))
+    print(f"Execution time: {time.time() - start:.2f}s")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -12,7 +12,9 @@ import time
 
 from dotenv import load_dotenv
 
-# Load environment variables (GOOGLE_API_KEY) from a .env file if present
+# Load environment variables from a .env file if present. The file should
+# include settings like GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, and
+# GOOGLE_APPLICATION_CREDENTIALS as shown in the ADK samples repository.
 load_dotenv()
 
 try:
@@ -27,14 +29,19 @@ except ImportError:
 
 from tygent.integrations.google_adk import patch
 
-API_KEY = os.getenv("GOOGLE_API_KEY")
-if not API_KEY:
-    print("GOOGLE_API_KEY environment variable not set.")
-    print("Get an API key from https://makersuite.google.com/app/apikey")
+# Ensure required environment variables for Vertex AI are set
+required_env_vars = [
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+]
+missing = [var for var in required_env_vars if not os.getenv(var)]
+if missing:
+    print("Missing required environment variables: " + ", ".join(missing))
     raise SystemExit
 
-# Configure Google GenAI client
-client = genai.Client(api_key=API_KEY)
+# Configure Google GenAI client using application default credentials
+client = genai.Client()
 
 # Create a simple LLM agent capable of explaining topics at different levels
 tag = LlmAgent(

--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -44,7 +44,7 @@ if missing:
 client = genai.Client()
 
 # Create a simple LLM agent capable of explaining topics at different levels
-model_name = os.getenv("GOOGLE_GENAI_MODEL", "gemini-1.0-pro")
+model_name = os.getenv("GOOGLE_GENAI_MODEL", "gemini-2.5-pro")
 tag = LlmAgent(
     name="spanner_explainer",
     model=model_name,

--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -44,20 +44,18 @@ if missing:
 client = genai.Client()
 
 # Create a simple LLM agent capable of explaining topics at different levels
+model_name = os.getenv("GOOGLE_GENAI_MODEL", "gemini-1.0-pro")
 tag = LlmAgent(
     name="spanner_explainer",
-    model="gemini-1.5-flash",
+    model=model_name,
     instruction=(
         "You explain technical topics for different levels of expertise."
         " Provide clear and concise responses."
     ),
 )
 
-# Create a runner and session
+# Create a runner
 runner = InMemoryRunner(tag)
-runner.session_service.create_session_sync(
-    app_name=runner.app_name, user_id="user", session_id="session"
-)
 
 QUERY = (
     "Describe the Spanner paper by Google assuming I am a 10th grader, "
@@ -97,6 +95,9 @@ async def run_with_tygent():
 
 
 async def main():
+    await runner.session_service.create_session(
+        app_name=runner.app_name, user_id="user", session_id="session"
+    )
     print("=== Without Tygent Acceleration ===")
     start = time.time()
     events = await run_without_tygent()

--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -20,7 +20,7 @@ load_dotenv()
 try:
     from google import genai
     from google.adk.agents.llm_agent import LlmAgent
-    from google.adk.runners import Runner
+    from google.adk.runners import InMemoryRunner
     from google.genai import types
 except ImportError:
     print("This example requires the google-adk and google-genai packages.")
@@ -54,7 +54,7 @@ tag = LlmAgent(
 )
 
 # Create a runner and session
-runner = Runner(tag)
+runner = InMemoryRunner(tag)
 runner.session_service.create_session_sync(
     app_name=runner.app_name, user_id="user", session_id="session"
 )

--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -28,7 +28,7 @@ except ImportError:
     print("Install them with: pip install google-adk google-genai")
     raise
 
-from tygent.integrations.google_adk import patch
+from tygent import accelerate
 
 # Ensure required environment variables for Vertex AI are set
 required_env_vars = [
@@ -73,7 +73,7 @@ async def run_without_tygent():
 
 
 async def run_with_tygent():
-    patch()  # Patch Runner.run_async to use Tygent scheduler
+    accelerate(runner)  # Enable Tygent acceleration for the runner
     content = types.Content(role="user", parts=[types.Part(text=QUERY)])
     async for _ in runner.run_async(
         user_id="user", session_id="session", new_message=content

--- a/examples/google_adk_spanner_example.py
+++ b/examples/google_adk_spanner_example.py
@@ -55,9 +55,6 @@ tag = LlmAgent(
     ),
 )
 
-# Create a runner
-runner = InMemoryRunner(tag)
-
 QUERY = (
     "Describe the Spanner paper by Google assuming I am a 10th grader, "
     "a junior undergraduate, and a first year graduate student."
@@ -65,6 +62,10 @@ QUERY = (
 
 
 async def run_without_tygent():
+    runner = InMemoryRunner(tag)
+    await runner.session_service.create_session(
+        app_name=runner.app_name, user_id="user", session_id="session"
+    )
     content = types.Content(role="user", parts=[types.Part(text=QUERY)])
     async for _ in runner.run_async(
         user_id="user", session_id="session", new_message=content
@@ -73,7 +74,11 @@ async def run_without_tygent():
 
 
 async def run_with_tygent():
-    accelerate(runner)  # Enable Tygent acceleration for the runner
+    runner = InMemoryRunner(tag)
+    accelerate(runner)
+    await runner.session_service.create_session(
+        app_name=runner.app_name, user_id="user", session_id="session"
+    )
     content = types.Content(role="user", parts=[types.Part(text=QUERY)])
     async for _ in runner.run_async(
         user_id="user", session_id="session", new_message=content
@@ -82,9 +87,6 @@ async def run_with_tygent():
 
 
 async def main():
-    await runner.session_service.create_session(
-        app_name=runner.app_name, user_id="user", session_id="session"
-    )
     start = time.time()
     await run_without_tygent()
     without_tygent = time.time() - start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,11 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "openai>=1.0.0",
     "aiohttp>=3.8",
-    "google-adk>=1.0.0",
-    "google-genai>=1.0.0",
+    "google-adk==0.0.1; python_version < '3.9'",
+    "google-adk>=1.0.0; python_version >= '3.9'",
+    "google-genai>=1.0.0; python_version >= '3.9'",
+    "openai>=1.0.0",
     "python-dotenv>=1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aiohttp>=3.8",
     "google-adk>=1.0.0",
     "google-genai>=1.0.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ requires-python = ">=3.7"
 dependencies = [
     "openai>=1.0.0",
     "aiohttp>=3.8",
+    "google-adk>=1.0.0",
+    "google-genai>=1.0.0",
 ]
 
 [project.urls]

--- a/tygent/integrations/google_adk.py
+++ b/tygent/integrations/google_adk.py
@@ -146,7 +146,8 @@ def patch() -> None:
 
         node.execute = run
         dag.add_node(node)
-        scheduler = Scheduler(dag)
+        hooks = getattr(self, "_tygent_hooks", None)
+        scheduler = Scheduler(dag, hooks=hooks)
         result = await scheduler.execute({})
         for event in result["results"]["call"]:
             yield event

--- a/tygent/integrations/google_adk.py
+++ b/tygent/integrations/google_adk.py
@@ -136,7 +136,8 @@ def patch() -> None:
 
     async def patched(self: Any, *args: Any, **kwargs: Any):
         dag = DAG("google_adk_run")
-        node = LLMNode("call", model=self)
+        node_name = getattr(getattr(self, "agent", None), "name", "call")
+        node = LLMNode(node_name, model=self)
 
         async def run(_):
             events = []
@@ -149,7 +150,7 @@ def patch() -> None:
         hooks = getattr(self, "_tygent_hooks", None)
         scheduler = Scheduler(dag, hooks=hooks)
         result = await scheduler.execute({})
-        for event in result["results"]["call"]:
+        for event in result["results"][node_name]:
             yield event
 
     setattr(Runner, "_tygent_run_async", original)


### PR DESCRIPTION
## Summary
- add example of a Google ADK agent that explains Google's Spanner paper at three education levels
- demonstrate running the agent with and without Tygent acceleration

## Testing
- `isort examples/google_adk_spanner_example.py`
- `black examples/google_adk_spanner_example.py`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891660dcd6083278f67b177415993f1