### PR TITLE
Add Google ADK market analysis example

### DIFF
--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -1,5 +1,8 @@
 """Example of using Tygent with Google ADK for comprehensive market analysis.
 
+Requires the `google-adk` and `google-genai` packages. Install them with:
+`pip install google-adk google-genai`.
+
 This script builds a directed acyclic graph (DAG) representing a multi-step
 market intelligence research workflow. It uses Google's Agent Development Kit
 (ADK) with an in-memory runner to execute each node in the workflow. The DAG

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -10,12 +10,9 @@ includes validation and synthesis stages before producing an executive summary.
 import asyncio
 from typing import Any, Dict
 
-try:  # pragma: no cover - optional dependency
-    from dotenv import load_dotenv
+from dotenv import load_dotenv
 
-    load_dotenv()
-except Exception:  # pragma: no cover - optional dependency
-    pass
+load_dotenv()
 
 try:  # pragma: no cover - optional dependency
     from google.adk.agents.base_agent import BaseAgent

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -17,14 +17,16 @@ import asyncio
 import os
 from typing import Any, Dict
 
-from dotenv import load_dotenv
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:  # pragma: no cover - optional dependency
+    pass
 
 from tygent.accelerate import accelerate
 
-load_dotenv()
-
 try:  # pragma: no cover - optional dependency
-    import google.genai as genai
     from google.adk.agents.llm_agent import LlmAgent
     from google.adk.runners import InMemoryRunner
     from google.genai import types
@@ -36,12 +38,11 @@ except Exception:  # pragma: no cover - optional dependency
     raise SystemExit(1)
 
 
-API_KEY = os.getenv("GOOGLE_API_KEY")
-if API_KEY:
-    genai.configure(api_key=API_KEY)
-else:
-    # Fall back to default credentials for Vertex AI / service account auth
-    genai.configure()
+if not os.getenv("GOOGLE_API_KEY") and not os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+    print(
+        "Set GOOGLE_API_KEY or GOOGLE_APPLICATION_CREDENTIALS before running this example."
+    )
+    raise SystemExit(1)
 
 
 INSTRUCTION = (
@@ -55,10 +56,9 @@ INSTRUCTION = (
 async def _create_integration() -> GoogleADKIntegration:
     """Set up the Google ADK integration with an LLM agent."""
 
-    model = genai.GenerativeModel("gemini-1.5-flash")
     agent = LlmAgent(
         name="analyst",
-        model=model,
+        model="gemini-1.5-flash",
         instruction=INSTRUCTION,
         generate_content_config=types.GenerateContentConfig(
             temperature=0.7, max_output_tokens=150

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -1,0 +1,198 @@
+"""Example of using Tygent with Google ADK for comprehensive market analysis.
+
+This script builds a directed acyclic graph (DAG) representing a multi-step
+market intelligence research workflow. It uses Google's Agent Development Kit
+(ADK) with an in-memory runner to execute each node in the workflow. The DAG
+structure mirrors the prompt-based plan described in the documentation and
+includes validation and synthesis stages before producing an executive summary.
+"""
+
+import asyncio
+from typing import Any, Dict
+
+from dotenv import load_dotenv
+
+# Load environment variables if present (for real ADK usage)
+load_dotenv()
+
+try:  # pragma: no cover - optional dependency
+    from google.adk.agents.base_agent import BaseAgent
+    from google.adk.events import Event
+    from google.adk.runners import InMemoryRunner
+    from google.genai import types
+
+    from tygent.integrations.google_adk import GoogleADKIntegration
+except Exception:  # pragma: no cover - optional dependency
+    print("This example requires the google-adk and google-genai packages.")
+    print("Install them with: pip install google-adk google-genai")
+    raise SystemExit(1)
+
+
+class EchoAgent(BaseAgent):
+    """Minimal agent that echoes the user's message."""
+
+    name: str = "echo"
+
+    async def _run_async_impl(self, ctx) -> Any:  # type: ignore[override]
+        text = ""
+        if ctx.user_content and ctx.user_content.parts:
+            text = ctx.user_content.parts[0].text
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            content=types.Content(role="model", parts=[types.Part(text=text)]),
+        )
+
+
+def _create_integration() -> GoogleADKIntegration:
+    """Set up the Google ADK integration with an in-memory runner."""
+
+    runner = InMemoryRunner(EchoAgent())
+    runner.session_service.create_session_sync(
+        app_name=runner.app_name, user_id="user", session_id="session"
+    )
+    integration = GoogleADKIntegration(runner)
+    integration.optimize({"maxParallelCalls": 8})
+    return integration
+
+
+BASE_PROMPT = (
+    "You are a strategic analyst preparing a comprehensive market intelligence report "
+    "for executive leadership. Research emerging trends, competitive threats, customer "
+    "behavior patterns, and market opportunities to guide major business decisions and "
+    "investment strategies.\n\n{task}: Analyze market opportunities, competitive landscape, "
+    "customer trends, and regulatory environment across multiple industries to inform "
+    "strategic business decisions."
+)
+
+
+def _build_dag(integration: GoogleADKIntegration) -> None:
+    """Construct the DAG described in the market analysis prompt."""
+
+    # Parallel Layer 1
+    integration.add_node(
+        "industry_analysis",
+        BASE_PROMPT.format(task="Analyze industry trends and market dynamics"),
+    )
+    integration.add_node(
+        "competitive_intelligence",
+        BASE_PROMPT.format(task="Research competitor strategies and positioning"),
+    )
+    integration.add_node(
+        "customer_research",
+        BASE_PROMPT.format(task="Analyze customer behavior and preferences"),
+    )
+    integration.add_node(
+        "regulatory_review",
+        BASE_PROMPT.format(
+            task="Review regulatory environment and compliance requirements"
+        ),
+    )
+    integration.add_node(
+        "trend_analysis",
+        BASE_PROMPT.format(task="Identify emerging market trends and opportunities"),
+    )
+    integration.add_node(
+        "expert_insights",
+        BASE_PROMPT.format(task="Gather expert opinions and industry analysis"),
+    )
+    integration.add_node(
+        "market_data",
+        BASE_PROMPT.format(task="Process market size, growth, and forecast data"),
+    )
+    integration.add_node(
+        "risk_assessment",
+        BASE_PROMPT.format(task="Assess market risks and business threats"),
+    )
+
+    # Parallel Layer 2
+    integration.add_node(
+        "cross_validation",
+        BASE_PROMPT.format(task="Cross-validate findings across research sources")
+        + " Sources: {industry_analysis}, {competitive_intelligence}, {customer_research}, {regulatory_review}",
+        dependencies=[
+            "industry_analysis",
+            "competitive_intelligence",
+            "customer_research",
+            "regulatory_review",
+        ],
+    )
+    integration.add_node(
+        "fact_verification",
+        BASE_PROMPT.format(task="Verify strategic insights and market claims")
+        + " Inputs: {trend_analysis}, {expert_insights}, {market_data}, {risk_assessment}",
+        dependencies=[
+            "trend_analysis",
+            "expert_insights",
+            "market_data",
+            "risk_assessment",
+        ],
+    )
+
+    # Sequential Layer 3
+    integration.add_node(
+        "credibility_assessment",
+        BASE_PROMPT.format(task="Assess source credibility")
+        + " References: {cross_validation}, {fact_verification}",
+        dependencies=["cross_validation", "fact_verification"],
+    )
+    integration.add_node(
+        "quality_check",
+        BASE_PROMPT.format(task="Quality control and data validation")
+        + " Review: {credibility_assessment}",
+        dependencies=["credibility_assessment"],
+    )
+
+    # Parallel Layer 4
+    integration.add_node(
+        "strategic_analysis",
+        BASE_PROMPT.format(
+            task="Synthesize market intelligence into strategic insights"
+        )
+        + " Data: {quality_check}",
+        dependencies=["quality_check"],
+    )
+    integration.add_node(
+        "opportunity_identification",
+        BASE_PROMPT.format(task="Identify strategic opportunities and recommendations")
+        + " Data: {quality_check}",
+        dependencies=["quality_check"],
+    )
+
+    # Final Layer 5
+    integration.add_node(
+        "executive_summary",
+        BASE_PROMPT.format(task="Compile executive market intelligence report")
+        + " Inputs: {strategic_analysis}, {opportunity_identification}",
+        dependencies=["strategic_analysis", "opportunity_identification"],
+    )
+
+
+def _extract(events: Any) -> str:
+    """Return the text content from a list of ADK events."""
+
+    if not events:
+        return ""
+    event = events[0]
+    content = getattr(event, "content", None)
+    parts = getattr(content, "parts", [])
+    if parts:
+        return parts[0].text
+    return str(event)
+
+
+async def main() -> None:
+    """Execute the market analysis DAG."""
+
+    print("=== Google ADK Market Intelligence Example ===\n")
+    integration = _create_integration()
+    _build_dag(integration)
+
+    results: Dict[str, Any] = await integration.execute({})
+    summary = _extract(results["executive_summary"])
+    print("Executive Summary:\n")
+    print(summary[:500])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -223,32 +223,41 @@ async def _call_runner(
 
 
 async def execute_plan(
-    runner: InMemoryRunner, log_usage: bool = False
+    runner: InMemoryRunner, log_usage: bool = False, parallel: bool = True
 ) -> Dict[str, str]:
     """Execute the predefined DAG and return node outputs."""
 
     results: Dict[str, str] = {}
     pending = {name: set(node.get("deps", [])) for name, node in PLAN.items()}
     while len(results) < len(PLAN):
-        ready = [
+        ready = sorted(
             name
             for name, deps in pending.items()
             if name not in results and deps.issubset(results.keys())
-        ]
-        tasks = {
-            name: asyncio.create_task(
-                _call_runner(
-                    runner,
-                    name,
-                    PLAN[name]["prompt"].format(**results),
-                    log_usage,
+        )
+        if parallel:
+            tasks = {
+                name: asyncio.create_task(
+                    _call_runner(
+                        runner,
+                        name,
+                        PLAN[name]["prompt"].format(**results),
+                        log_usage,
+                    )
                 )
+                for name in ready
+            }
+            outputs = await asyncio.gather(*tasks.values())
+            for name, text in zip(tasks.keys(), outputs):
+                results[name] = text
+        else:
+            name = ready[0]
+            results[name] = await _call_runner(
+                runner,
+                name,
+                PLAN[name]["prompt"].format(**results),
+                log_usage,
             )
-            for name in ready
-        }
-        outputs = await asyncio.gather(*tasks.values())
-        for name, text in zip(tasks.keys(), outputs):
-            results[name] = text
     return results
 
 
@@ -264,7 +273,7 @@ async def main(log_usage: bool = False) -> None:
 
     print("=== Standard Execution ===")
     start = asyncio.get_event_loop().time()
-    results = await execute_plan(runner, log_usage)
+    results = await execute_plan(runner, log_usage, parallel=False)
     standard_time = asyncio.get_event_loop().time() - start
     print("Executive Summary:\n")
     print(results["executive_summary"][:500])

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -61,100 +61,113 @@ BASE_PROMPT = (
     "business decisions."
 )
 
-PLAN: Dict[str, Dict[str, Any]] = {
-    "industry_analysis": {
-        "prompt": BASE_PROMPT.format(
-            task="Analyze industry trends and market dynamics"
-        ),
-        "deps": [],
-    },
-    "competitive_intelligence": {
-        "prompt": BASE_PROMPT.format(
-            task="Research competitor strategies and positioning"
-        ),
-        "deps": [],
-    },
-    "customer_research": {
-        "prompt": BASE_PROMPT.format(task="Analyze customer behavior and preferences"),
-        "deps": [],
-    },
-    "regulatory_review": {
-        "prompt": BASE_PROMPT.format(
-            task="Review regulatory environment and compliance requirements"
-        ),
-        "deps": [],
-    },
-    "trend_analysis": {
-        "prompt": BASE_PROMPT.format(
-            task="Identify emerging market trends and opportunities"
-        ),
-        "deps": [],
-    },
-    "expert_insights": {
-        "prompt": BASE_PROMPT.format(
-            task="Gather expert opinions and industry analysis"
-        ),
-        "deps": [],
-    },
-    "market_data": {
-        "prompt": BASE_PROMPT.format(
-            task="Process market size, growth, and forecast data"
-        ),
-        "deps": [],
-    },
-    "risk_assessment": {
-        "prompt": BASE_PROMPT.format(task="Assess market risks and business threats"),
-        "deps": [],
-    },
-    "cross_validation": {
-        "prompt": BASE_PROMPT.format(
-            task="Cross-validate findings across research sources"
-        )
-        + " Sources: {industry_analysis}, {competitive_intelligence}, {customer_research}, {regulatory_review}",
-        "deps": [
-            "industry_analysis",
-            "competitive_intelligence",
-            "customer_research",
-            "regulatory_review",
-        ],
-    },
-    "fact_verification": {
-        "prompt": BASE_PROMPT.format(task="Verify strategic insights and market claims")
-        + " Inputs: {trend_analysis}, {expert_insights}, {market_data}, {risk_assessment}",
-        "deps": ["trend_analysis", "expert_insights", "market_data", "risk_assessment"],
-    },
-    "credibility_assessment": {
-        "prompt": BASE_PROMPT.format(task="Assess source credibility")
-        + " References: {cross_validation}, {fact_verification}",
-        "deps": ["cross_validation", "fact_verification"],
-    },
-    "quality_check": {
-        "prompt": BASE_PROMPT.format(task="Quality control and data validation")
-        + " Review: {credibility_assessment}",
-        "deps": ["credibility_assessment"],
-    },
-    "strategic_analysis": {
-        "prompt": BASE_PROMPT.format(
-            task="Synthesize market intelligence into strategic insights"
-        )
-        + " Data: {quality_check}",
-        "deps": ["quality_check"],
-    },
-    "opportunity_identification": {
-        "prompt": BASE_PROMPT.format(
-            task="Identify strategic opportunities and recommendations"
-        )
-        + " Data: {quality_check}",
-        "deps": ["quality_check"],
-    },
-    "executive_summary": {
-        "prompt": BASE_PROMPT.format(
-            task="Compile executive market intelligence report"
-        )
-        + " Inputs: {strategic_analysis}, {opportunity_identification}",
-        "deps": ["strategic_analysis", "opportunity_identification"],
-    },
-}
+
+def build_plan() -> Dict[str, Dict[str, Any]]:
+    return {
+        "industry_analysis": {
+            "prompt": BASE_PROMPT.format(
+                task="Analyze industry trends and market dynamics"
+            ),
+            "deps": [],
+        },
+        "competitive_intelligence": {
+            "prompt": BASE_PROMPT.format(
+                task="Research competitor strategies and positioning"
+            ),
+            "deps": [],
+        },
+        "customer_research": {
+            "prompt": BASE_PROMPT.format(
+                task="Analyze customer behavior and preferences"
+            ),
+            "deps": [],
+        },
+        "regulatory_review": {
+            "prompt": BASE_PROMPT.format(
+                task="Review regulatory environment and compliance requirements"
+            ),
+            "deps": [],
+        },
+        "trend_analysis": {
+            "prompt": BASE_PROMPT.format(
+                task="Identify emerging market trends and opportunities"
+            ),
+            "deps": [],
+        },
+        "expert_insights": {
+            "prompt": BASE_PROMPT.format(
+                task="Gather expert opinions and industry analysis"
+            ),
+            "deps": [],
+        },
+        "market_data": {
+            "prompt": BASE_PROMPT.format(
+                task="Process market size, growth, and forecast data"
+            ),
+            "deps": [],
+        },
+        "risk_assessment": {
+            "prompt": BASE_PROMPT.format(
+                task="Assess market risks and business threats"
+            ),
+            "deps": [],
+        },
+        "cross_validation": {
+            "prompt": BASE_PROMPT.format(
+                task="Cross-validate findings across research sources"
+            )
+            + " Sources: {industry_analysis}, {competitive_intelligence}, {customer_research}, {regulatory_review}",
+            "deps": [
+                "industry_analysis",
+                "competitive_intelligence",
+                "customer_research",
+                "regulatory_review",
+            ],
+        },
+        "fact_verification": {
+            "prompt": BASE_PROMPT.format(
+                task="Verify strategic insights and market claims"
+            )
+            + " Inputs: {trend_analysis}, {expert_insights}, {market_data}, {risk_assessment}",
+            "deps": [
+                "trend_analysis",
+                "expert_insights",
+                "market_data",
+                "risk_assessment",
+            ],
+        },
+        "credibility_assessment": {
+            "prompt": BASE_PROMPT.format(task="Assess source credibility")
+            + " References: {cross_validation}, {fact_verification}",
+            "deps": ["cross_validation", "fact_verification"],
+        },
+        "quality_check": {
+            "prompt": BASE_PROMPT.format(task="Quality control and data validation")
+            + " Review: {credibility_assessment}",
+            "deps": ["credibility_assessment"],
+        },
+        "strategic_analysis": {
+            "prompt": BASE_PROMPT.format(
+                task="Synthesize market intelligence into strategic insights"
+            )
+            + " Data: {quality_check}",
+            "deps": ["quality_check"],
+        },
+        "opportunity_identification": {
+            "prompt": BASE_PROMPT.format(
+                task="Identify strategic opportunities and recommendations"
+            )
+            + " Data: {quality_check}",
+            "deps": ["quality_check"],
+        },
+        "executive_summary": {
+            "prompt": BASE_PROMPT.format(
+                task="Compile executive market intelligence report"
+            )
+            + " Inputs: {strategic_analysis}, {opportunity_identification}",
+            "deps": ["strategic_analysis", "opportunity_identification"],
+        },
+    }
 
 
 async def _create_runner() -> InMemoryRunner:
@@ -223,12 +236,14 @@ async def _call_runner(
 
 
 async def execute_plan(
-    runner: InMemoryRunner, log_usage: bool = False
+    plan: Dict[str, Dict[str, Any]],
+    runner: InMemoryRunner,
+    log_usage: bool = False,
 ) -> Dict[str, str]:
-    """Execute the predefined DAG sequentially in defined order."""
+    """Execute the provided DAG sequentially in defined order."""
 
     results: Dict[str, str] = {}
-    for name, node in PLAN.items():
+    for name, node in plan.items():
         results[name] = await _call_runner(
             runner,
             name,
@@ -238,11 +253,15 @@ async def execute_plan(
     return results
 
 
-def build_tygent_plan(runner: InMemoryRunner, log_usage: bool) -> Dict[str, Any]:
-    """Build a Tygent-compatible plan from the predefined DAG."""
+def build_tygent_plan(
+    plan: Dict[str, Dict[str, Any]],
+    runner: InMemoryRunner,
+    log_usage: bool,
+) -> Dict[str, Any]:
+    """Build a Tygent-compatible plan from the provided DAG."""
 
     steps: List[Dict[str, Any]] = []
-    for name, node in PLAN.items():
+    for name, node in plan.items():
         prompt = node["prompt"]
 
         async def step(inputs: Dict[str, str], name=name, prompt=prompt):
@@ -267,17 +286,18 @@ async def main(log_usage: bool = False) -> None:
 
     print("=== Google ADK Market Intelligence Example ===\n")
     runner = await _create_runner()
+    plan = build_plan()
 
     print("=== Standard Execution ===")
     start = asyncio.get_event_loop().time()
-    results = await execute_plan(runner, log_usage)
+    results = await execute_plan(plan, runner, log_usage)
     standard_time = asyncio.get_event_loop().time() - start
     print("Executive Summary:\n")
     print(results["executive_summary"][:500])
     print(f"\nStandard execution time: {standard_time:.2f} seconds\n")
 
     print("=== Accelerated Execution ===")
-    accelerated_plan = accelerate(build_tygent_plan(runner, log_usage))
+    accelerated_plan = accelerate(build_tygent_plan(plan, runner, log_usage))
     start = asyncio.get_event_loop().time()
     accel_results = await accelerated_plan({})
     accel_time = asyncio.get_event_loop().time() - start

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -299,7 +299,8 @@ async def main(log_usage: bool = False) -> None:
     print("=== Accelerated Execution ===")
     accelerated_plan = accelerate(build_tygent_plan(plan, runner, log_usage))
     start = asyncio.get_event_loop().time()
-    accel_results = await accelerated_plan({})
+    accel_raw = await accelerated_plan({})
+    accel_results = accel_raw["results"]
     accel_time = asyncio.get_event_loop().time() - start
     print("Executive Summary:\n")
     print(accel_results["executive_summary"][:500])

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -46,11 +46,11 @@ class EchoAgent(BaseAgent):
         )
 
 
-def _create_integration() -> GoogleADKIntegration:
+async def _create_integration() -> GoogleADKIntegration:
     """Set up the Google ADK integration with an in-memory runner."""
 
     runner = InMemoryRunner(EchoAgent())
-    runner.session_service.create_session_sync(
+    await runner.session_service.create_session(
         app_name=runner.app_name, user_id="user", session_id="session"
     )
     integration = GoogleADKIntegration(runner)
@@ -187,7 +187,7 @@ async def main() -> None:
     """Execute the market analysis DAG."""
 
     print("=== Google ADK Market Intelligence Example ===\n")
-    integration = _create_integration()
+    integration = await _create_integration()
     _build_dag(integration)
 
     results: Dict[str, Any] = await integration.execute({})

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -10,10 +10,12 @@ includes validation and synthesis stages before producing an executive summary.
 import asyncio
 from typing import Any, Dict
 
-from dotenv import load_dotenv
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
 
-# Load environment variables if present (for real ADK usage)
-load_dotenv()
+    load_dotenv()
+except Exception:  # pragma: no cover - optional dependency
+    pass
 
 try:  # pragma: no cover - optional dependency
     from google.adk.agents.base_agent import BaseAgent

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -1,8 +1,10 @@
 """Example of using Tygent with Google ADK for comprehensive market analysis.
 
 Requires the `google-adk` and `google-genai` packages. Install them with:
-`pip install google-adk google-genai` and set the ``GOOGLE_API_KEY``
-environment variable.
+`pip install google-adk google-genai` and configure authentication using either
+an API key (`GOOGLE_API_KEY`) or Google Cloud service account credentials
+(`GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and
+`GOOGLE_CLOUD_LOCATION`).
 
 This script builds a directed acyclic graph (DAG) representing a multi-step
 market intelligence research workflow. It uses Google's Agent Development Kit
@@ -33,12 +35,11 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 API_KEY = os.getenv("GOOGLE_API_KEY")
-if not API_KEY:
-    print("GOOGLE_API_KEY environment variable not set.")
-    print("Get an API key from https://aistudio.google.com/app/apikey")
-    raise SystemExit(1)
-
-genai.configure(api_key=API_KEY)
+if API_KEY:
+    genai.configure(api_key=API_KEY)
+else:
+    # Fall back to default credentials for Vertex AI / service account auth
+    genai.configure()
 
 
 INSTRUCTION = (

--- a/examples/google_adk_market_analysis.py
+++ b/examples/google_adk_market_analysis.py
@@ -17,9 +17,12 @@ import asyncio
 import os
 from typing import Any, Dict
 
-from dotenv import load_dotenv
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
 
-load_dotenv()
+    load_dotenv()
+except Exception:  # pragma: no cover - optional dependency
+    pass
 
 try:  # pragma: no cover - optional dependency
     import google.genai as genai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "openai>=1.0.0",
     "aiohttp>=3.8",
     "python-dotenv",
+    "google-adk",
+    "google-genai",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ requires-python = ">=3.7"
 dependencies = [
     "openai>=1.0.0",
     "aiohttp>=3.8",
+    "python-dotenv",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     "openai>=1.0.0",
     "aiohttp>=3.8",
     "python-dotenv",
-    "google-adk",
-    "google-genai",
+    "google-adk; python_version >= '3.9'",
+    "google-genai; python_version >= '3.9'",
 ]
 
 [project.urls]

--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -10,7 +10,11 @@ EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 SKIP_REQUIREMENTS = {
     "google_ai_example.py": "GOOGLE_API_KEY",
-    "google_adk_market_analysis.py": "GOOGLE_API_KEY",
+    # Run the ADK example only if an API key or service-account credentials are present
+    "google_adk_market_analysis.py": [
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ],
     "microsoft_ai_example.py": "AZURE_OPENAI_KEY",
     "salesforce_example.py": "SALESFORCE_USERNAME",
 }
@@ -22,11 +26,15 @@ OPTIONAL_MODULES = {
 results = []
 
 for example in sorted(EXAMPLES_DIR.glob("*.py")):
-    env_var = SKIP_REQUIREMENTS.get(example.name)
-    if env_var and env_var not in os.environ:
-        print(f"Skipping {example.name} (missing {env_var})")
-        results.append((example.name, None, False, None))
-        continue
+    env_vars = SKIP_REQUIREMENTS.get(example.name)
+    if env_vars:
+        if isinstance(env_vars, str):
+            env_vars = [env_vars]
+        if not any(var in os.environ for var in env_vars):
+            missing = ", ".join(env_vars)
+            print(f"Skipping {example.name} (missing {missing})")
+            results.append((example.name, None, False, None))
+            continue
 
     module_names = OPTIONAL_MODULES.get(example.name)
     if module_names:

--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -9,10 +9,13 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 SKIP_REQUIREMENTS = {
-    "google_ai_example.py": "GOOGLE_API_KEY",
-    "google_adk_market_analysis.py": "GOOGLE_API_KEY",
-    "microsoft_ai_example.py": "AZURE_OPENAI_KEY",
-    "salesforce_example.py": "SALESFORCE_USERNAME",
+    "google_ai_example.py": ["GOOGLE_API_KEY"],
+    "google_adk_market_analysis.py": [
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ],
+    "microsoft_ai_example.py": ["AZURE_OPENAI_KEY"],
+    "salesforce_example.py": ["SALESFORCE_USERNAME"],
 }
 
 OPTIONAL_MODULES = {
@@ -22,11 +25,15 @@ OPTIONAL_MODULES = {
 results = []
 
 for example in sorted(EXAMPLES_DIR.glob("*.py")):
-    env_var = SKIP_REQUIREMENTS.get(example.name)
-    if env_var and env_var not in os.environ:
-        print(f"Skipping {example.name} (missing {env_var})")
-        results.append((example.name, None, False, None))
-        continue
+    env_vars = SKIP_REQUIREMENTS.get(example.name)
+    if env_vars:
+        if isinstance(env_vars, str):
+            env_vars = [env_vars]
+        if not any(v in os.environ for v in env_vars):
+            missing = " or ".join(env_vars)
+            print(f"Skipping {example.name} (missing {missing})")
+            results.append((example.name, None, False, None))
+            continue
 
     module_names = OPTIONAL_MODULES.get(example.name)
     if module_names:

--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -10,11 +10,7 @@ EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 SKIP_REQUIREMENTS = {
     "google_ai_example.py": "GOOGLE_API_KEY",
-    # Run the ADK example only if an API key or service-account credentials are present
-    "google_adk_market_analysis.py": [
-        "GOOGLE_API_KEY",
-        "GOOGLE_APPLICATION_CREDENTIALS",
-    ],
+    "google_adk_market_analysis.py": "GOOGLE_API_KEY",
     "microsoft_ai_example.py": "AZURE_OPENAI_KEY",
     "salesforce_example.py": "SALESFORCE_USERNAME",
 }
@@ -26,15 +22,11 @@ OPTIONAL_MODULES = {
 results = []
 
 for example in sorted(EXAMPLES_DIR.glob("*.py")):
-    env_vars = SKIP_REQUIREMENTS.get(example.name)
-    if env_vars:
-        if isinstance(env_vars, str):
-            env_vars = [env_vars]
-        if not any(var in os.environ for var in env_vars):
-            missing = ", ".join(env_vars)
-            print(f"Skipping {example.name} (missing {missing})")
-            results.append((example.name, None, False, None))
-            continue
+    env_var = SKIP_REQUIREMENTS.get(example.name)
+    if env_var and env_var not in os.environ:
+        print(f"Skipping {example.name} (missing {env_var})")
+        results.append((example.name, None, False, None))
+        continue
 
     module_names = OPTIONAL_MODULES.get(example.name)
     if module_names:

--- a/scripts/benchmark_examples.py
+++ b/scripts/benchmark_examples.py
@@ -10,6 +10,7 @@ EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 SKIP_REQUIREMENTS = {
     "google_ai_example.py": "GOOGLE_API_KEY",
+    "google_adk_market_analysis.py": "GOOGLE_API_KEY",
     "microsoft_ai_example.py": "AZURE_OPENAI_KEY",
     "salesforce_example.py": "SALESFORCE_USERNAME",
 }

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,7 @@ setup(
         "openai>=1.0.0",
         "aiohttp>=3.8",
         "python-dotenv",
+        "google-adk",
+        "google-genai",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "openai>=1.0.0",
         "aiohttp>=3.8",
         "python-dotenv",
-        "google-adk",
-        "google-genai",
+        "google-adk; python_version >= '3.9'",
+        "google-genai; python_version >= '3.9'",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
     install_requires=[
         "openai>=1.0.0",
         "aiohttp>=3.8",
+        "python-dotenv",
     ],
 )

--- a/tygent/integrations/google_adk.py
+++ b/tygent/integrations/google_adk.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class GoogleADKNode(LLMNode):
 
         events = []
         usage = None
+        start = time.time()
         async for event in self.runner.run_async(
             user_id=self.user_id,
             session_id=self.session_id,
@@ -69,17 +71,21 @@ class GoogleADKNode(LLMNode):
             events.append(event)
             if usage is None:
                 usage = getattr(event, "usage_metadata", None)
+        duration = time.time() - start
         if usage is not None:
             prompt_tokens = getattr(usage, "prompt_token_count", None)
             response_tokens = getattr(usage, "candidates_token_count", None)
             logger.info(
-                "%s: %s input tokens, %s output tokens",
+                "%s executed in %.2fs: %s input tokens, %s output tokens",
                 self.name,
+                duration,
                 prompt_tokens,
                 response_tokens,
             )
         else:
-            logger.info("%s: token counts unavailable", self.name)
+            logger.info(
+                "%s executed in %.2fs: token counts unavailable", self.name, duration
+            )
         # Wrap the result so dependency names map to unique keys
         return {self.name: events}
 

--- a/tygent/scheduler.py
+++ b/tygent/scheduler.py
@@ -333,6 +333,10 @@ class Scheduler:
 
         # Apply mappings from edge metadata to input fields
         for dep_name, dep_output in dependency_outputs.items():
+            # Normalize outputs so simple types map to their dependency name
+            if not isinstance(dep_output, dict):
+                dep_output = {dep_name: dep_output}
+
             # Check if we have a mapping for this dependency
             if (
                 dep_name in dag.edge_mappings


### PR DESCRIPTION
## Summary
- add a Google ADK market intelligence DAG example demonstrating multi-layer workflow execution

## Testing
- `isort examples/google_adk_market_analysis.py`
- `black examples/google_adk_market_analysis.py`
- `pip install -e .`
- `pip install google-adk google-genai`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892ac35ca008327ac7cd1273c07d7a3